### PR TITLE
Feature compiler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Script tag support for TypeScript
 ## Usage
 Add the following lines at the bottom of your page: 
 ```html
-<script src="https://rawgit.com/Microsoft/TypeScript/master/lib/typescriptServices.js"></script>
-<script src="https://rawgit.com/basarat/typescript-script/master/transpiler.js"></script>
+<script src="https://raw.githack.com/Microsoft/TypeScript/master/lib/typescriptServices.js"></script>
+<script src="https://raw.githack.com/basarat/typescript-script/master/transpiler.js"></script>
 ```
 
 And then you can use script tags that load `.ts` files or even have `typescript` inline: 
@@ -14,6 +14,21 @@ And then you can use script tags that load `.ts` files or even have `typescript`
 <script type="text/typescript">
     setTimeout(()=>console.log('hello'));
 </script>
+```
+
+Optionally you can pass `compilerOptions` to the TypeScript transpiler:
+```html
+<script type="text/typescript" data-compiler-options='{ "target": "es5", "module": "none"}' src="script.ts"></script>
+<script type="text/typescript">
+    setTimeout(()=>console.log('hello'));
+</script>
+```
+
+If you are not using a module loader and just need a quick hack if you attempt to export from your module add this to the bottom instead:
+```
+<script>var exports = {};</script>
+<script src="https://raw.githack.com/Microsoft/TypeScript/master/lib/typescriptServices.js"></script>
+<script src="https://raw.githack.com/basarat/typescript-script/master/transpiler.js"></script>
 ```
 
 ## Sample

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Optionally you can pass `compilerOptions` to the TypeScript transpiler:
 ```
 
 If you are not using a module loader and just need a quick hack if you attempt to export from your module add this to the bottom instead:
-```
+```html
 <script>var exports = {};</script>
 <script src="https://raw.githack.com/Microsoft/TypeScript/master/lib/typescriptServices.js"></script>
 <script src="https://raw.githack.com/basarat/typescript-script/master/transpiler.js"></script>


### PR DESCRIPTION
Optionally you can pass `compilerOptions` to the TypeScript transpiler:
```html
<script type="text/typescript" data-compiler-options='{ "target": "es5", "module": "none"}' src="script.ts"></script>
<script type="text/typescript">
    setTimeout(()=>console.log('hello'));
</script>
```

If you are not using a module loader and just need a quick hack if you attempt to export from your module add this to the bottom instead:
```html
<script>var exports = {};</script>
<script src="https://raw.githack.com/Microsoft/TypeScript/master/lib/typescriptServices.js"></script>
<script src="https://raw.githack.com/basarat/typescript-script/master/transpiler.js"></script>
```

#### TODO
Optionally you should be able to tell the transpiler service to generate es module script tags for a complete solution without a hack, if desired I could add this to this PR or add another PR, functional as is without this extra sugar.
```html
<script type="text/typescript" data-compiler-options='{ "target": "es5" }' data-type="module" src="script.ts"></script>
<!-- would generate this -->
<script type="module">
//Compiled Typescript
...
</script>
```